### PR TITLE
Adding state filter because pumas are only unique within a state. The ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ v# Misc data files
 *.h5
 *.omx
 
-# ActivitySim files
+# Data files
 data/
 output/
 examples/sample_data/2010_puma_tract_mapping.txt

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ v# Misc data files
 # ActivitySim files
 data/
 output/
+examples/sample_data/2010_puma_tract_mapping.txt
 
 # Visual Studio
 *.vscode
@@ -143,3 +144,6 @@ nose_stub.py
 
 # Ctags
 tags
+
+# Run Files which contain protected creds
+run/

--- a/doppelganger/datasource.py
+++ b/doppelganger/datasource.py
@@ -43,12 +43,12 @@ class PumsData(DirtyDataSource):
 
     @staticmethod
     def from_database(
-        conn, puma_id, table_name, fields
+        conn, state_id, puma_id, table_name, fields
     ):
         columns = ', '.join(field.pums_name for field in fields)
         query = (
-            'SELECT {} FROM import.{} WHERE PUMA=\'{}\' ORDER BY SERIALNO'
-        ).format(columns, table_name, puma_id)
+            'SELECT {} FROM import.{} WHERE ST=\'{}\' AND PUMA=\'{}\' ORDER BY SERIALNO'
+        ).format(columns, table_name, state_id, puma_id)
         return PumsData(pandas.read_sql_query(query, conn))
 
     @staticmethod

--- a/doppelganger/marginals.py
+++ b/doppelganger/marginals.py
@@ -89,7 +89,7 @@ class Marginals(object):
         return full_controls
 
     @staticmethod
-    def from_census_data(puma_tract_mappings, census_key, pumas=None):
+    def from_census_data(puma_tract_mappings, census_key, state=None, puma=None):
         """Fetch marginal sums from the census API.
 
         Args:
@@ -103,18 +103,20 @@ class Marginals(object):
 
             census_key (unicode): census API key
 
-            pumas (iterable of unicode): a list of pumas to fetch for.  If the
-                parameter is not passed in will fetch for all pumas in
-                puma_tract_mappings
+            pumas (unicode): a puma to fetch for.
 
         Returns:
             Marginals: marginals fetched from the census API
 
         """
         data = []
+        if not puma or not state:
+            raise ValueError('''Please supply a state fips code and a puma.
+                    https://www.mcc.co.mercer.pa.us/dps/state_fips_code_listing.htm''')
 
         for line in puma_tract_mappings:
-            if pumas is not None and line['PUMA5CE'] not in pumas:
+            if state is None or puma is None\
+                    or line['STATEFP'] != state or line['PUMA5CE'] != puma:
                 continue
             state_key = line['STATEFP']
             tract_key = line['TRACTCE']
@@ -153,19 +155,21 @@ class Marginals(object):
         return Marginals(pandas.DataFrame(data, columns=columns))
 
     @staticmethod
-    def from_csv(infile, puma=None):
+    def from_csv(infile, state=None, puma=None):
         """Load marginals from file.
 
         Args:
             infile (unicode): path to csv
+            state (unicode): state fips code (2-digit)
+            puma (unicode): puma code (5-digit)
 
         Returns:
-            Marginals: marginals fetched from the census API
+            Marginals: marginals fetched from a csv file
 
         """
         data = pandas.read_csv(infile)
-        if puma is not None:
-            data = data[data['PUMA5CE'] == int(puma)]
+        if state is not None and puma is not None:
+            data = data[data['STATEFP'] == int(state) and data['PUMA5CE'] == int(puma)]
         return Marginals(data)
 
     def write(self, outfile):

--- a/doppelganger/marginals.py
+++ b/doppelganger/marginals.py
@@ -112,7 +112,7 @@ class Marginals(object):
         data = []
         if not puma or not state:
             raise ValueError('''Please supply a state fips code and a puma.
-                    https://www.mcc.co.mercer.pa.us/dps/state_fips_code_listing.htm''')
+                    https://www.census.gov/geo/reference/ansi_statetables.html''')
 
         for line in puma_tract_mappings:
             if state is None or puma is None\

--- a/doppelganger/marginals.py
+++ b/doppelganger/marginals.py
@@ -89,7 +89,7 @@ class Marginals(object):
         return full_controls
 
     @staticmethod
-    def from_census_data(puma_tract_mappings, census_key, state=None, pumas=None):
+    def from_census_data(puma_tract_mappings, census_key, state=None, puma=None):
         """Fetch marginal sums from the census API.
 
         Args:
@@ -103,20 +103,20 @@ class Marginals(object):
 
             census_key (unicode): census API key
 
-            pumas (list(unicode)): a puma to fetch for.
+            pumas (unicode): a puma to fetch for.
 
         Returns:
             Marginals: marginals fetched from the census API
 
         """
         data = []
-        if not pumas or not state:
+        if not puma or not state:
             raise ValueError('''Please supply a state fips code and a puma.
                     https://www.census.gov/geo/reference/ansi_statetables.html''')
 
         for line in puma_tract_mappings:
-            if state is None or pumas is None\
-                    or line['STATEFP'] != state or line['PUMA5CE'] not in pumas:
+            if state is None or puma is None\
+                    or line['STATEFP'] != state or line['PUMA5CE'] != puma:
                 continue
             state_key = line['STATEFP']
             tract_key = line['TRACTCE']

--- a/doppelganger/marginals.py
+++ b/doppelganger/marginals.py
@@ -89,7 +89,7 @@ class Marginals(object):
         return full_controls
 
     @staticmethod
-    def from_census_data(puma_tract_mappings, census_key, state=None, puma=None):
+    def from_census_data(puma_tract_mappings, census_key, state=None, pumas=None):
         """Fetch marginal sums from the census API.
 
         Args:
@@ -103,20 +103,20 @@ class Marginals(object):
 
             census_key (unicode): census API key
 
-            pumas (unicode): a puma to fetch for.
+            pumas (list(unicode)): a puma to fetch for.
 
         Returns:
             Marginals: marginals fetched from the census API
 
         """
         data = []
-        if not puma or not state:
+        if not pumas or not state:
             raise ValueError('''Please supply a state fips code and a puma.
                     https://www.census.gov/geo/reference/ansi_statetables.html''')
 
         for line in puma_tract_mappings:
-            if state is None or puma is None\
-                    or line['STATEFP'] != state or line['PUMA5CE'] != puma:
+            if state is None or pumas is None\
+                    or line['STATEFP'] != state or line['PUMA5CE'] not in pumas:
                 continue
             state_key = line['STATEFP']
             tract_key = line['TRACTCE']

--- a/doppelganger/marginals.py
+++ b/doppelganger/marginals.py
@@ -89,7 +89,7 @@ class Marginals(object):
         return full_controls
 
     @staticmethod
-    def from_census_data(puma_tract_mappings, census_key, state=None, puma=None):
+    def from_census_data(puma_tract_mappings, census_key, state=None, pumas=None):
         """Fetch marginal sums from the census API.
 
         Args:
@@ -103,20 +103,22 @@ class Marginals(object):
 
             census_key (unicode): census API key
 
-            pumas (unicode): a puma to fetch for.
+            pumas (iterable of unicode): a list of pumas to fetch for.  If the
+                parameter is not passed in will fetch for all pumas in
+                puma_tract_mappings
 
         Returns:
             Marginals: marginals fetched from the census API
 
         """
         data = []
-        if not puma or not state:
+        if not pumas or not state:
             raise ValueError('''Please supply a state fips code and a puma.
                     https://www.census.gov/geo/reference/ansi_statetables.html''')
 
         for line in puma_tract_mappings:
-            if state is None or puma is None\
-                    or line['STATEFP'] != state or line['PUMA5CE'] != puma:
+            if state is None or pumas is None\
+                    or line['STATEFP'] != state or line['PUMA5CE'] not in pumas:
                 continue
             state_key = line['STATEFP']
             tract_key = line['TRACTCE']

--- a/examples/doppelganger_example_full.ipynb
+++ b/examples/doppelganger_example_full.ipynb
@@ -71,6 +71,7 @@
    },
    "outputs": [],
    "source": [
+    "STATE = '06'\n",
     "PUMA = '00106'"
    ]
   },
@@ -441,7 +442,7 @@
     "with open('sample_data/2010_puma_tract_mapping.txt') as csv_file:\n",
     "    csv_reader = csv.DictReader(csv_file)\n",
     "    marginals = Marginals.from_census_data(\n",
-    "        csv_reader, MY_CENSUS_KEY, pumas=[PUMA]\n",
+    "        csv_reader, MY_CENSUS_KEY, state=STATE, puma=PUMA\n",
     "    )\n",
     "    marginals.write(new_marginal_filename)"
    ]

--- a/test/test_marginals.py
+++ b/test/test_marginals.py
@@ -58,7 +58,7 @@ class MarginalsTest(unittest.TestCase):
                    return_value=self._mock_response()):
             marg = Marginals.from_census_data(
                     puma_tract_mappings=self._mock_marginals_file(), census_key=None,
-                    state=state, puma=puma
+                    state=state, pumas=set([puma])
                 )
         expected = {
             'STATEFP': '06',

--- a/test/test_marginals.py
+++ b/test/test_marginals.py
@@ -52,11 +52,14 @@ class MarginalsTest(unittest.TestCase):
                  '075', '023001']))
 
     def test_fetch_marginals(self):
+        state = self._mock_marginals_file()[0]['STATEFP']
         puma = self._mock_marginals_file()[0]['PUMA5CE']
         with patch('doppelganger.marginals.Marginals._fetch_from_census',
                    return_value=self._mock_response()):
             marg = Marginals.from_census_data(
-                self._mock_marginals_file(), set([puma]))
+                    puma_tract_mappings=self._mock_marginals_file(), census_key=None,
+                    state=state, puma=puma
+                )
         expected = {
             'STATEFP': '06',
             'COUNTYFP': '075',

--- a/test/test_marginals.py
+++ b/test/test_marginals.py
@@ -58,7 +58,7 @@ class MarginalsTest(unittest.TestCase):
                    return_value=self._mock_response()):
             marg = Marginals.from_census_data(
                     puma_tract_mappings=self._mock_marginals_file(), census_key=None,
-                    state=state, pumas=set([puma])
+                    state=state, puma=puma
                 )
         expected = {
             'STATEFP': '06',


### PR DESCRIPTION
… example_full jupyter notebook has been updated accordingly. Simple example uses pre-canned data -- which should be replaced because puma-00106 isn't unique to California. Adding line in gitignore to ignore the tract-puma relations file, so the unzipped version isn't accidentally added to this repo in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sidewalklabs/doppelganger/33)
<!-- Reviewable:end -->
